### PR TITLE
Fix Consumer Memory Leak: Hanging promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulsar-flex",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "A package that natively supports pulsar api",
   "main": "src/index.js",
   "scripts": {

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -330,7 +330,7 @@ module.exports = class Consumer {
     };
     await this._flow(this._receiveQueueSize);
     this._logger.trace(`Started processing messages...`);
-    await process().catch((e) => {
+    process().catch((e) => {
        this._logger.error(`Error with the first process call, error: ${e}`);
     });
   };

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -291,9 +291,7 @@ module.exports = class Consumer {
         this._receiveQueue.isEmpty() ||
         (this._isRedeliveringUnacknowledgedMessages && this._prioritizeUnacknowledgedMessages)
       ) {
-        this._processTimeoutInterval = setTimeout(async () => {
-          await process();
-        }, 1000);
+        this._processTimeoutInterval = setTimeout(process, 1000);
         return;
       }
       const message = this._receiveQueue.dequeue();
@@ -319,7 +317,8 @@ module.exports = class Consumer {
             ackType: options.type ? options.type : ACK_TYPES.INDIVIDUAL,
           }),
       });
-      await process();
+      process();
+      return;
     };
     await this._flow(this._receiveQueueSize);
     await process();

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -330,6 +330,8 @@ module.exports = class Consumer {
     };
     await this._flow(this._receiveQueueSize);
     this._logger.trace(`Started processing messages...`);
-    await process();
+    await process().catch((e) => {
+       this._logger.error(`Error with the first process call, error: ${e}`);
+    });
   };
 };


### PR DESCRIPTION
Fixes #79 

`await process()` will never be resolved due to the function calling itself again and again causing unused references to dequeued messages to stay alive, resulting in a memory leak.

Made process() call asynchronous and added `return` when the function ends.