### PR TITLE
Consumer State Change Handling Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ const run = async () => {
   ]});
 
   await consumer.subscribe();
+  consumer.onStateChange({
+    stateChangeHandler: ({previousState, newState}) => {
+      console.log(`Consumer previous state ${previousState}.`)
+      console.log(`Consumer new state ${newState}.`)
+    }
+  })
   await consumer.run({
     onMessage: async ({ ack, message, properties, redeliveryCount }) => {
       await ack(); // Default is individual ack

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -187,6 +187,7 @@ module.exports = class Consumer {
       }) STATE: ${this.getState()}`
     );
     if (this._onStateChangeHandler) {
+      this._logger.debug('Executing consumer state change handler.');
       this._onStateChangeHandler({ previousState, newState: this._consumerState });
     }
   };


### PR DESCRIPTION
implements this #81 

Allow the users of this library to "listen" to change in the consumer state without needing to check at intervals.

Since this PR isn't adding anything new to the consumer's logic, but just exports some of the inners nicely, I didn't add anything tests, open for suggestions though.
