### PR TITLE
moved consumer's stateChangeHandler out of constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,6 @@ const consumer = new Consumer({
   receiveQueueSize: 1000,
   logLevel: logLevel.INFO,
   // you can also provide logCreator function
-  stateChangeHandler: ({previousState, newState}) => {
-    console.log(`Consumer previous state ${previousState}.`)
-    console.log(`Consumer new state ${newState}.`)
-  }
 })
 
 const run = async () => {
@@ -101,6 +97,12 @@ const run = async () => {
   ]});
 
   await consumer.subscribe();
+
+  consumer.onStateChange(({previousState, newState}) => {
+      console.log(`Consumer state has changed from ${previousState} to ${newState}.`);
+    };
+  );
+
   await consumer.run({
     onMessage: async ({ ack, message, properties, redeliveryCount }) => {
       await ack(); // Default is individual ack

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulsar-flex",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.1",
   "description": "A package that natively supports pulsar api",
   "main": "src/index.js",
   "scripts": {

--- a/scripts/test-setup.js
+++ b/scripts/test-setup.js
@@ -21,7 +21,7 @@ console.log(`Setting up environment using JWT and pulsar standalone version ${ve
     await asyncExec(`docker rm ${containerName} -f`);
     console.log(`Successfully found and removed docker with name ${containerName}`);
   } catch (e) {
-    console.log(`Did not found docker with name ${containerName}`);
+    console.log(`Did not find docker with name ${containerName}`);
   }
 
   const dockerComposeFilePath = path.join(
@@ -57,16 +57,16 @@ console.log(`Setting up environment using JWT and pulsar standalone version ${ve
     console.log(`Found a running pulsar container, continuing`);
   }
 
-  console.log('Creating test topic public/default/test');
+  console.log('Creating test topic "public/default/test"');
   await asyncExec(
     `docker exec ${containerName} /pulsar/bin/pulsar-admin topics create public/default/test`
   );
-  console.log('Creating subscription subscription');
+  console.log('Creating "subscription" subscription');
 
   await asyncExec(
     `docker exec ${containerName} /pulsar/bin/pulsar-admin topics create-subscription -s subscription public/default/test`
   );
 
-  console.log('You can run the your tests now!');
+  console.log('You can run your tests now!');
   process.exit(0);
 })();

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -36,7 +36,6 @@ module.exports = class Consumer {
     reconnectInterval = 5000,
     logLevel,
     logCreator = defaultLogger,
-    stateChangeHandler = null,
   }) {
     this._logger = createLogger({ logLevel, logCreator });
     this._client = new Pulsar({
@@ -64,7 +63,7 @@ module.exports = class Consumer {
     this._onMessageParams = {};
     this._processTimeoutInterval = null;
 
-    this._onStateChangeHandler = stateChangeHandler;
+    this._onStateChangeHandler = null;
 
     this._receiveQueue = new PriorityQueue({
       maxQueueSize: receiveQueueSize,
@@ -195,6 +194,13 @@ module.exports = class Consumer {
         this._logger.error(`Error executing state change handler function ${e}.`);
       }
     }
+  };
+
+  onStateChange = (stateChangeHandler) => {
+    this._onStateChangeHandler = stateChangeHandler;
+    this._logger.info(
+      `Set new state change handler for consumer: ${this._consumerName}(${this._consumerId})`
+    );
   };
 
   _setRedeliveringUnacknowledgedMessages = (redeliveringUnacknowledgedMessages) => {


### PR DESCRIPTION
setting the consumer's `stateChangeHandler` should be more flexible, setting it inside the consumer's constructor does not fit all use cases and limits its usability. This PR moves it outside the consturctor into a property so it can be accessed anytime during the consumer's existence.