### PR TITLE
Add Subscription to Sample Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ const producer = new Producer({
 
 const consumer = new Consumer({
   topic: "persistent://public/default/my-topic",
+  subscription: "my-subscription",
   discoveryServers: ['pulsar-host:6650'],
   jwt: process.env.JWT_TOKEN,
   subType: Consumer.SUB_TYPES.EXCLUSIVE,


### PR DESCRIPTION
### Motivation
When the sample code in README is executed, the following logs are output on the client and server.

Client:
```
PulsarFlexResponseTimeoutError: Timeout waiting for response for request id: 0 from the Broker
```

Server:
```
2022-09-07T10:44:06,378+0900 [pulsar-io-18-2] WARN  org.apache.pulsar.broker.service.ServerCnx - [/127.0.0.1:62247] Got exception java.lang.IllegalStateException: Some required fields are missing
	at org.apache.pulsar.common.api.proto.CommandSubscribe.checkRequiredFields(CommandSubscribe.java:922)
```

It appears that this is due to the fact that `"subscription"` is not specified when creating Consumer.

### Modification
Add `"subscription"` explicitly.

